### PR TITLE
meta: ignore non-existing keys when deleting

### DIFF
--- a/src/artifact_store/__init__.py
+++ b/src/artifact_store/__init__.py
@@ -31,10 +31,7 @@ class ArtifactMetaData:
             raise ValueError(f"Invalid metadata format '{kv}', expected key=value")
         key, value = kv.split('=', 1)
         if value == '':
-            if key in self.meta:
-                del self.meta[key]
-            else:
-                raise KeyError(f"Key '{key}' not found in metadata")
+            self.meta.pop(key, None)
             return None, None
         else:
             self.add(key, value)

--- a/src/artifact_store/cli.py
+++ b/src/artifact_store/cli.py
@@ -236,8 +236,6 @@ def meta(args):
             vprint(f"  handled: '{item}' -> '{key}' = '{value}'")
         except ValueError as e:
             fatal(e)
-        except KeyError as e:
-            fatal(e)
 
     print(meta.dump(show_hidden=args.show_hidden))
     meta.save(meta_file)

--- a/tests/test_cli_meta.py
+++ b/tests/test_cli_meta.py
@@ -116,7 +116,10 @@ def test_cll_meta_invaled_key(init_fs):
     assert e.value.code == 1
 
 
-def test_cli_meta_delete_unknown_key(init_fs):
-    with pytest.raises(SystemExit) as e:
-        main(["meta", "-r", "1", "project/a", "artifact1", "unknownkey="])
-    assert e.value.code == 1
+def test_cli_meta_delete_unknown_key(init_fs, capsys):
+    main(["meta", "-r", "1", "project/a", "artifact1", "unknownkey="])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == """{
+  "a": "1",
+  "b": "test"
+}"""


### PR DESCRIPTION
Non existing keys are not an error when deleting one.